### PR TITLE
increase file size without actually telling the user on frontend

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -112,12 +112,12 @@ const conf = convict({
   },
   max_file_size: {
     format: Number,
-    default: 2 * 1024 * 1024 * 1024,
+    default: 10 * 1024 * 1024 * 1024,
     env: 'MAX_FILE_SIZE'
   },
   anon_max_file_size: {
     format: Number,
-    default: 2 * 1024 * 1024 * 1024,
+    default: 10 * 1024 * 1024 * 1024,
     env: 'ANON_MAX_FILE_SIZE'
   },
   l10n_dev: {


### PR DESCRIPTION
This PR will allow a large file to be uploaded, but still tell the user that files only up to 2GB are allowed, in case this feature doesn't work as expected. Need to test this on staging to get any guarantee about its efficacy. If it doesn't work, we'll roll back. Merge if approved!