### PR TITLE
Update README.md's Windows note with a better fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,12 @@ To deploy this project locally for development purposes, follow the steps below.
 
 ### Note for Windows users
 
-If you are on Windows, ensure that you are using [Git Bash](https://git-scm.com/downloads) because the npm scripts contain Bash commands.
+If you are on Windows, ensure that you are using [Git Bash](https://git-scm.com/downloads) because the `npm run` scripts contain Bash shell commands.
 
-You will also need to set `"start-dev": "bash npm_scripts/start-dev.sh"` in `package.json`, and create a new file `npm_scripts/start-dev.sh` containing the original command in `"start-dev"`:
+You will also need to configure npm to use Git Bash:  
+`npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"`
 
-```
-#!/bin/bash
-npm run clean && cross-env NODE_ENV=development L10N_DEV=true FXA_CLIENT_ID=fced6b5e3f4c66b9 BASE_URL=http://localhost:8080 webpack-dev-server --mode=development
-```
-
- This is because the npm scripts will always run in the default Windows shell rather than Git Bash. See [Stack Overflow](https://stackoverflow.com/questions/42107780/npm-script-under-cygwin-windows-the-syntax-of-the-command-is-incorrect/42108180#42108180) for more information.
+You can find more information [here](https://www.evantay.com/docs/full-stack/nodejs/set-npm-run-shell/).
 
 # Original README
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ If you are on Windows, ensure that you are using [Git Bash](https://git-scm.com/
 You will also need to configure npm to use Git Bash:  
 `npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"`
 
-You can find more information [here](https://www.evantay.com/docs/full-stack/nodejs/set-npm-run-shell/).
-
 # Original README
 
 ## [![Firefox Send](./assets/icon.svg)](https://send.firefox.com/) Firefox Send


### PR DESCRIPTION
**What:**
Update `README.md`'s Windows note with a better fix which is much more sustainable and easier.
Instead of instructing Windows users to modify the `npm run` scripts in `package.json` and create new files, the new instruction simply asks them to enter a one-line command to fix the issue permanently.

**Why:**
- Way faster and permanent fix.
- No need to `git stash` the modified `package.json` and `npm_scripts` directories created too.

**Before:**
You will also need to set `"start-dev": "bash npm_scripts/start-dev.sh"` in `package.json`, and create a new file `npm_scripts/start-dev.sh` containing the original command in `"start-dev"`:

```
#!/bin/bash
npm run clean && cross-env NODE_ENV=development L10N_DEV=true FXA_CLIENT_ID=fced6b5e3f4c66b9 BASE_URL=http://localhost:8080 webpack-dev-server --mode=development
```

 This is because the npm scripts will always run in the default Windows shell rather than Git Bash. See [Stack Overflow](https://stackoverflow.com/questions/42107780/npm-script-under-cygwin-windows-the-syntax-of-the-command-is-incorrect/42108180#42108180) for more information.

**After:**
You will also need to configure npm to use Git Bash:  
`npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"`

You can find more information [here](https://www.evantay.com/docs/full-stack/nodejs/set-npm-run-shell/).