### PR TITLE
Replace redirect_url with redirect_key to prevent malicious redirection

### DIFF
--- a/env_example
+++ b/env_example
@@ -2,6 +2,7 @@
 export AWS_ACCESS_KEY_ID=""
 export AWS_SECRET_ACCESS_KEY=""
 export LOGIN_URL="http://localhost:8082"
+export SEND_FRONTEND_REDIRECT_KEY="send" # Must match its counterpart in the main Vault project
 export LOGGING_URL="http://localhost:4000/secret_datasets"
 export COOKIE_SECRET="blahblahblah"
 export COOKIE_DOMAIN="localhost"

--- a/server/config.js
+++ b/server/config.js
@@ -9,6 +9,11 @@ const conf = convict({
     default: 'http://localhost:1443',
     env: 'LOGIN_URL'
   },
+  SEND_FRONTEND_REDIRECT_KEY: {
+    format: String,
+    default: 'send',
+    env: 'SEND_FRONTEND_REDIRECT_KEY'
+  },
   s3_bucket: {
     format: String,
     default: 'secret-storage-test.vault.gov.sg',

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -108,7 +108,12 @@ module.exports = function(app) {
     if (req.session.email) {
       return next();
     } else {
-      const redirect_uri = `${config.LOGIN_URL}/login?redirect_key=${config.SEND_FRONTEND_REDIRECT_KEY}`;
+      const download_id = req.originalUrl.match('(?<=/download/).*$');
+      // If it is a redirect to a download link, append download_id and # tag
+      // A valid Vault Send download link requires /download/download_id/#download_tag
+      const redirect_uri = download_id
+        ? `${config.LOGIN_URL}/login?redirect_key=${config.SEND_FRONTEND_REDIRECT_KEY}&download_id=${download_id}`
+        : `${config.LOGIN_URL}/login?redirect_key=${config.SEND_FRONTEND_REDIRECT_KEY}`;
       return res.redirect(redirect_uri);
     }
   };

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -108,11 +108,7 @@ module.exports = function(app) {
     if (req.session.email) {
       return next();
     } else {
-      const redirect_uri = `${
-        config.LOGIN_URL
-      }/login?redirect_uri=${encodeURIComponent(
-        req.protocol + '://' + req.get('host') + req.originalUrl
-      )}`;
+      const redirect_uri = `${config.LOGIN_URL}/login?redirect_key=${config.SEND_FRONTEND_REDIRECT_KEY}`;
       return res.redirect(redirect_uri);
     }
   };

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -108,6 +108,9 @@ module.exports = function(app) {
     if (req.session.email) {
       return next();
     } else {
+      // The Regex below removes '/download/' from the '/download/download_id/' URL
+      // It will be added back by the Vault app, therefore only allowing redirection
+      // to the Send landing page or '/download/*' pages.
       const download_id = req.originalUrl.match('(?<=/download/).*$');
       // If it is a redirect to a download link, append download_id and # tag
       // A valid Vault Send download link requires /download/download_id/#download_tag


### PR DESCRIPTION
## Description

[VT-143: WEB-M-03: URL Redirection Exposed Application to Phishing Attacks](https://team-1582686133065.atlassian.net/browse/VT-143?atlOrigin=eyJpIjoiYzdmODRmYzg3NzMzNDVlZDgxYTExMDExZTA0ZTBiYjMiLCJwIjoiaiJ9)

**Problem:**  
The application uses URL redirection technique to transfer the user to the requested internal web page. There is however no validation performed on the value of redirection URL which may allow an attacker to launch effective phishing attacks against the application and redirect user to any third-party malicious web site.

**Solution:**  
Modify query string to use a key value instead of a url. This PR is to be merged in conjunction with its [counterpart](https://github.com/datagovsg/vaultgovsg/pull/733) at the main Vault codebase.

**Change log:**

- Replace query parameter `redirect_uri` with `redirect_key` in `server/routes/index.js`.
- Add query parameter `download_id` for redirection to download links.
- Update `server/config.js` with the new environment variable SEND_FRONTEND_REDIRECT_KEY.
- Update `.env-example` with said new environment variable and a comment explaining what it is for

## Decisions/Tradeoffs
**Suggested solutions:**

- [ ] Figure out how to whitelist redirect URIs server side to address WEB-M-03: URL Redirection Exposed Application to Phishing Attacks (low effort)
- [x] Modify query string to use a key value instead of a url.
ie /login?redirect=send the redirect to url for send on frontend. (super low effort) 

**Decision:**  
The second option was chosen because the additional code complexity (and associated maintenance and greater security risk) of implementing a whitelist is not worth it now, given we are only redirecting to one link (`LOGIN_URL`) currently. We can consider implementing a whitelist if the list of redirect links get too long in future (>10 links?), but for now [YAGNI](https://martinfowler.com/bliki/Yagni.html).

## How to test
Pre-requisite: You are logged out of Vault

1. Visit Vault Send landing page: http://localhost:8080
    - You should be redirected to Vault login page: http://localhost:8082/login?redirect_key=send
2. Log into Vault
    - You should be redirected to the Send landing page: http://localhost:8080/
3. Upload a file and copy the download link down
4. Log out of Send
    - You should be redirected to Vault login page: http://localhost:8082/login?redirect_key=send
5. Paste the download link into your browser URL bar and visit it
    - You should be redirected to the Vault Send landing page with a similar URL: http://localhost:8082/login?redirect_key=send&download_id=85ea1e0031cd016f/#gEsm7Ip5_2rG6-KicBfpbQ
6. Log into Vault
    - You should be redirected to the Send download link successfully

## Type of change. 

- Breaking change (fix or feature that would cause existing functionality to not work as expected)