### PR TITLE
Add await to logout API call

### DIFF
--- a/app/controller.js
+++ b/app/controller.js
@@ -137,7 +137,7 @@ export default function(state, emitter) {
 
   emitter.on('vaultLogout', async () => {
     try {
-      invalidateVaultSession();
+      await invalidateVaultSession();
       // Force reload the application to trigger vaultSessionMgmt again
       window.location.replace('/');
     } catch (e) {


### PR DESCRIPTION
## Description
Add `await` to logout API call. Sometimes the redirection occurs before the API call completes. This causes the user to be redirected to the Vault login page and then redirected back again to the Send page. Even though the user is logged out even if this happens, because it only completes after the second redirection, the user is not redirected to the Vault login page and remains on the Send page.

Not a major issue since the user can "log out" a second time but should be fixed.

## How to test
1. Login to Vault
2. Visit the Send page
3. Logout
    - You should not need to click it more than once
4. Repeat steps 1. to 3. a few times 😅 

## Type of change
- Bug fix (non-breaking change which fixes an issue)
