### PR TITLE
Configure ASG deployment to use ELB health check

### DIFF
--- a/.ebextensions/autoscaling.config
+++ b/.ebextensions/autoscaling.config
@@ -1,0 +1,6 @@
+Resources:
+  AWSEBAutoScalingGroup:
+    Type: "AWS::AutoScaling::AutoScalingGroup"
+    Properties:
+      HealthCheckType: ELB
+      HealthCheckGracePeriod: 3600

--- a/.ebextensions/autoscaling.config
+++ b/.ebextensions/autoscaling.config
@@ -3,4 +3,4 @@ Resources:
     Type: "AWS::AutoScaling::AutoScalingGroup"
     Properties:
       HealthCheckType: ELB
-      HealthCheckGracePeriod: 3600
+      HealthCheckGracePeriod: 300


### PR DESCRIPTION
## Description
### Background
The AWS Auto-Scaling Group deployment uses EC2 instance health checks instead of ELB health checks. The ELB health checks are more comprehensive and appropriate.

 _from [AWS's documentation on Health Checks for Auto Scaling Instances](https://docs.aws.amazon.com/autoscaling/ec2/userguide/healthcheck.html#determine-instance-health)_:  
"Instances for groups that do not use ELB health checks are considered healthy if they are in the running state. Instances for groups that use ELB health checks are considered healthy if they are in the running state **and they are reported as healthy by the load balancer**."  

### Problem
We often have EC2 instances providing degraded service (according to the ELB load balancer) for an extended period of time. These instances are not automatically terminated and replaced even though they fail ELB health checks. This is because they pass EC2 health checks which are the default health checks used by the ASG. Additionally, manual reboot is required sometimes too.

### Solution
Configure ASG to use ELB instead of EC2 health checks. Note that because we use immutable deploys, new ASGs are created each deploy. So even if we change the health check setting to ELB manually for each ASG via the interface, this change will not persist across deploys.

See for more info:

- [Advanced environment customization with configuration files (.ebextensions)](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/ebextensions.html)
- [AWS::AutoScaling::AutoScalingGroup](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html)
- [Auto Scaling health check setting](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environmentconfig-autoscaling-healthchecktype.html)

## Decisions/Tradeoffs
None really. The ELB checks are a superset of EC2 checks.

`HealthCheckGracePeriod` is set to 300 seconds to prevent instances from being killed prematurely.

 _from [AWS's documentation on AWS::AutoScaling::AutoScalingGroup](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html)_:  
"HealthCheckGracePeriod: The amount of time, in seconds, that Amazon EC2 Auto Scaling waits before checking the health status of an EC2 instance that has come into service. The default value is 0."

## Screenshots
N/A

## How to test
After an immutable deploy, check if the new ASG has the health check configured to ELB instead of the default EC2.

## Type of change
- Refactor (non-breaking change which improves development experience or performance of product)

## Deploy Notes
Verify it works by following the test section.