### PR TITLE
Update header and footer

### DIFF
--- a/app/css/main.css
+++ b/app/css/main.css
@@ -184,6 +184,10 @@ footer {
   align-items: center;
 }
 
+.footerContainer a:hover, .footerContainer a:hover * {
+  text-decoration: underline;
+}
+
 .leftFooter {
   width: 50%;
   display: block;

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -184,10 +184,6 @@ footer {
   align-items: center;
 }
 
-.footerContainer a:hover, .footerContainer a:hover * {
-  text-decoration: underline;
-}
-
 .leftFooter {
   width: 50%;
   display: block;
@@ -206,6 +202,10 @@ footer {
 }
 
 .rightFooter a:hover {
+  text-decoration: underline;
+}
+
+.footerContainer a:hover, .footerContainer a:hover * {
   text-decoration: underline;
 }
 

--- a/app/ui/footer.js
+++ b/app/ui/footer.js
@@ -1,5 +1,5 @@
-const html = require("choo/html");
-const Component = require("choo/component");
+const html = require('choo/html');
+const Component = require('choo/component');
 
 class Footer extends Component {
   constructor(name, state) {
@@ -17,19 +17,14 @@ class Footer extends Component {
         <div class="footerContainer">
           <div class="leftFooter">
             <a
-              href="${this.state.vaultFrontendUrl}/about"
+              href="${window.DEFAULTS.LOGIN_URL}/about"
               title="Find out more about us."
             >
               © 2020 Open Government Products
             </a>
           </div>
           <div class="rightFooter">
-            <a
-              href="${this.state.vaultFrontendUrl ||
-                window.DEFAULTS.LOGIN_URL ||
-                "/"}"
-              rel="noopener noreferrer"
-            >
+            <a href="${window.DEFAULTS.LOGIN_URL}" rel="noopener noreferrer">
               <i class="bx bx-arrow-back"></i> Return to Vault
             </a>
           </div>

--- a/app/ui/footer.js
+++ b/app/ui/footer.js
@@ -17,14 +17,17 @@ class Footer extends Component {
         <div class="footerContainer">
           <div class="leftFooter">
             <a
-              href="${window.DEFAULTS.LOGIN_URL}/about"
+              href="${window.DEFAULTS.LOGIN_URL || ''}/about"
               title="Find out more about us."
             >
               © 2020 Open Government Products
             </a>
           </div>
           <div class="rightFooter">
-            <a href="${window.DEFAULTS.LOGIN_URL}" rel="noopener noreferrer">
+            <a
+              href="${window.DEFAULTS.LOGIN_URL || ''}"
+              rel="noopener noreferrer"
+            >
               <i class="bx bx-arrow-back"></i> Return to Vault
             </a>
           </div>

--- a/app/ui/footer.js
+++ b/app/ui/footer.js
@@ -1,5 +1,5 @@
-const html = require('choo/html');
-const Component = require('choo/component');
+const html = require("choo/html");
+const Component = require("choo/component");
 
 class Footer extends Component {
   constructor(name, state) {
@@ -16,16 +16,21 @@ class Footer extends Component {
       <footer>
         <div class="footerContainer">
           <div class="leftFooter">
-            © 2020 Open Government Products - A Division of GovTech
+            <a
+              href="${this.state.vaultFrontendUrl}/about"
+              title="Find out more about us."
+            >
+              © 2020 Open Government Products
+            </a>
           </div>
           <div class="rightFooter">
             <a
               href="${this.state.vaultFrontendUrl ||
                 window.DEFAULTS.LOGIN_URL ||
-                '/'}"
+                "/"}"
               rel="noopener noreferrer"
-              >Return to Vault
-              <i class="bx bx-link-external"></i>
+            >
+              <i class="bx bx-arrow-back"></i> Return to Vault
             </a>
           </div>
         </div>

--- a/app/ui/header.js
+++ b/app/ui/header.js
@@ -46,7 +46,7 @@ class Header extends Component {
                   '/'}"
               >
                 <i class="bx bx-arrow-back"></i>
-                <div>Back</div>
+                <div>Return to Vault</div>
               </a>
               <a href="/vault-logout">
                 <i class="bx bx-exit"></i>

--- a/app/ui/header.js
+++ b/app/ui/header.js
@@ -18,41 +18,28 @@ class Header extends Component {
   }
 
   createElement() {
-    const title =
-      platform() === 'android'
-        ? html`
-            <a class="flex flex-row items-center">
-              <img src="${assets.get('icon.svg')}" />
-            </a>
-          `
-        : html`
-            <div class="flex">
-              <a
-                class="flex flex-row items-center"
-                href="${window.DEFAULTS.LOGIN_URL}"
-              >
-                <img
-                  alt="${this.state.translate('title')}"
-                  src="${assets.get('icon.svg')}"
-                />
-              </a>
-            </div>
-            <div class="main-nav flex">
-              <a href="${window.DEFAULTS.LOGIN_URL}">
-                <i class="bx bx-arrow-back"></i>
-                <div>Return to Vault</div>
-              </a>
-              <a href="/vault-logout">
-                <i class="bx bx-exit"></i>
-                <div>Logout</div>
-              </a>
-            </div>
-          `;
     return html`
       <header
         class="main-header relative flex-none flex flex-row w-full z-20 bg-white"
       >
-        ${title} ${this.account.render()}
+        <div class="flex">
+          <a class="flex flex-row items-center" href="">
+            <img
+              alt="${this.state.translate('title')}"
+              src="${assets.get('icon.svg')}"
+            />
+          </a>
+        </div>
+        <div class="main-nav flex">
+          <a href="${window.DEFAULTS.LOGIN_URL || ''}">
+            <i class="bx bx-arrow-back"></i>
+            <div>Return to Vault</div>
+          </a>
+          <a href="/vault-logout">
+            <i class="bx bx-exit"></i>
+            <div>Logout</div>
+          </a>
+        </div>
       </header>
     `;
   }

--- a/app/ui/header.js
+++ b/app/ui/header.js
@@ -29,9 +29,7 @@ class Header extends Component {
             <div class="flex">
               <a
                 class="flex flex-row items-center"
-                href="${this.state.vaultFrontendUrl ||
-                  window.DEFAULTS.LOGIN_URL ||
-                  '/'}"
+                href="${window.DEFAULTS.LOGIN_URL}"
               >
                 <img
                   alt="${this.state.translate('title')}"
@@ -40,11 +38,7 @@ class Header extends Component {
               </a>
             </div>
             <div class="main-nav flex">
-              <a
-                href="${this.state.vaultFrontendUrl ||
-                  window.DEFAULTS.LOGIN_URL ||
-                  '/'}"
-              >
+              <a href="${window.DEFAULTS.LOGIN_URL}">
                 <i class="bx bx-arrow-back"></i>
                 <div>Return to Vault</div>
               </a>

--- a/app/ui/header.js
+++ b/app/ui/header.js
@@ -2,7 +2,6 @@ const html = require('choo/html');
 const Component = require('choo/component');
 const Account = require('./account');
 const assets = require('../../common/assets');
-const { platform } = require('../utils');
 
 class Header extends Component {
   constructor(name, state, emit) {

--- a/server/state.js
+++ b/server/state.js
@@ -34,7 +34,6 @@ module.exports = async function(req) {
     description:
       'Encrypt and send files with a link that automatically expires to ensure your important documents don’t stay on our servers forever.',
     baseUrl: config.base_url,
-    vaultFrontendUrl: config.LOGIN_URL,
     ui: {},
     storage: {
       files: []


### PR DESCRIPTION
## Description

- Update Vault Send's footer to match update for Vault's footer
- Standardise the CTA for returning to Vault by modifying the header's CTA to be a replica of the footer's equivalent CTA

## Decisions/Tradeoffs
N/A

## Screenshots

### Before
<img width="1536" alt="Screenshot 2020-06-12 at 11 34 31 AM" src="https://user-images.githubusercontent.com/13582874/84462200-f9911080-aca0-11ea-8f5e-725739bf747f.png">

### After
<img width="1536" alt="Screenshot 2020-06-12 at 11 33 55 AM" src="https://user-images.githubusercontent.com/13582874/84462201-fac23d80-aca0-11ea-83c0-aed877d8742d.png">

## How to test
N/A

## Type of change
- UI improvement (non-breaking change which improves the UI)

## Deploy Notes
N/A