### PR TITLE
chore: more console log statements

### DIFF
--- a/server/routes/download.js
+++ b/server/routes/download.js
@@ -19,6 +19,7 @@ module.exports = async function(req, res) {
     fileStream.pipe(res).on('finish', async () => {
       console.log('filestream pipe has finished');
       if (cancelled) {
+        console.log('damn son you were cancelled');
         return;
       }
 
@@ -41,8 +42,10 @@ module.exports = async function(req, res) {
           await storage.incrementField(id, 'dl');
         }
       } catch (e) {
+        console.log('you have faced some sort of an error here', e);
         log.info('StorageError:', id);
       }
+      console.log('okay the entire thing is done');
     });
   } catch (e) {
     res.sendStatus(404);


### PR DESCRIPTION
I forgot to give you an explanation of the problem. I saw this in the logs:

![image](https://user-images.githubusercontent.com/10901999/95863185-768ade80-0d96-11eb-96dc-7daca2d640a9.png)

This means that the nodejs server is killing the connection for some reason. That's why I raised the last PR. Now, I see this in the logs at almost exactly the same time that the connection died for me:

![image](https://user-images.githubusercontent.com/10901999/95863264-928e8000-0d96-11eb-835c-7235a70c0d9c.png)

Which means that the filestream pipe has finished streaming to the nodejs server, but it's not streaming downwards to our browser? I'm not fully sure what's happening. I'm just hypothesising by shooting from my hip. Let me see what happens