### PR TITLE
fix: lock node to 10.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "cache": true
   },
   "engines": {
-    "node": ">=10.0.0 <11.0.0"
+    "node": "10.19.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.2",


### PR DESCRIPTION
## Description
Fixes Send to the currently working version 10.19.0
